### PR TITLE
40 fix 카드리스트 페이지 카드 이전 다음 버튼 포지셔닝 이탈

### DIFF
--- a/rolling-papaer/src/components/button/NextButton.jsx
+++ b/rolling-papaer/src/components/button/NextButton.jsx
@@ -11,7 +11,7 @@ function NextBaseButton({ onClick, className }) {
 const NextButton = styled(NextBaseButton)`
   position: absolute;
   top: 19rem;
-  right: 8.4rem;
+  right: -2rem;
   z-index: 1;
 `;
 

--- a/rolling-papaer/src/components/button/PrevButton.jsx
+++ b/rolling-papaer/src/components/button/PrevButton.jsx
@@ -12,6 +12,6 @@ function PrevBaseButton({ onClick, className }) {
 const PrevButton = styled(PrevBaseButton)`
   position: absolute;
   top: 19rem;
-  left: 8.6rem;
+  left: -2rem;
 `;
 export default PrevButton;

--- a/rolling-papaer/src/pages/rolling-paper-page/CardSection.jsx
+++ b/rolling-papaer/src/pages/rolling-paper-page/CardSection.jsx
@@ -8,14 +8,15 @@ import NextButton from "../../components/button/NextButton";
 import PrevButton from "../../components/button/PrevButton";
 
 const Section = styled.section`
+  width: 116rem;
   position: relative;
+  margin: 5rem auto 1.6rem;
 `;
 const Title = styled.h2`
   ${FONTS.FONT_24_BOLD}
 `;
 const CardSection = styled(BaseSection)`
   width: 116rem;
-  margin: 5rem auto 1.6rem;
   overflow: hidden;
 `;
 const CardContainer = styled.div`


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
기존 리스트 페이지 버튼 포지셔닝이 브라우저 사이즈에 따라 이탈하는 현상이 있어서 수정하였습니다 . 



## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #32 
- Closes #32 

## 스크린샷, 녹화
![image](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/148178373/121101e9-3006-4438-9c70-eb295d9528c9)
![image](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/148178373/1fc4f3ce-c90a-4aeb-9eb4-be9551ec5711)

_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?