### PR TITLE
Day7 이나경 43 fix postheader 좌우 padding

### DIFF
--- a/rolling-papaer/src/components/header/PostHeader/PostHeader.jsx
+++ b/rolling-papaer/src/components/header/PostHeader/PostHeader.jsx
@@ -1,0 +1,73 @@
+import styled from "styled-components";
+import FONTS from "../../../theme/font";
+import { useContext } from "react";
+import {
+  PostHeaderProvider,
+  usePostHeaderContextValue,
+} from "./PostHeaderProvider";
+import PostHeaderItems from "./PostHeaderItems";
+import { THEME_LIGHT_COLOR } from "../../../theme/color";
+
+const PostHeaderBlock = styled.header`
+  width: 100%;
+  height: 68px;
+
+  padding: 13px 360px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const testPostSummaryData = {
+  name: "강영훈",
+  messageCount: "12",
+  topReactions: [
+    {
+      id: 27,
+      emoji: "😀",
+      count: 14,
+    },
+    {
+      id: 31,
+      emoji: "🥹",
+      count: 11,
+    },
+    {
+      id: 31,
+      emoji: "🥹",
+      count: 11,
+    },
+  ],
+};
+
+const ReceiverNameBlock = styled.p`
+  margin: 0;
+  ${FONTS.FONT_28_BOLD}
+  color: ${THEME_LIGHT_COLOR.gray8};
+  line-height: 4.2rem;
+  letter-spacing: -0.028rem;
+`;
+
+function ReceiverName() {
+  const { name } = usePostHeaderContextValue();
+
+  return <ReceiverNameBlock>To. {name}</ReceiverNameBlock>;
+}
+
+function PostHeader({ postSummaryData = testPostSummaryData }) {
+  return (
+    <PostHeaderProvider defaultValue={postSummaryData}>
+      <PostHeaderBlock>
+        <ReceiverName/>
+        <PostHeaderItems>
+          <div>//TODO:몇명이 작성했어요</div>
+          <div>//TODO:이모지 보기 | 추가하기</div>
+          <div>//TODO:공유버튼</div>
+        </PostHeaderItems>
+      </PostHeaderBlock>
+    </PostHeaderProvider>
+  );
+}
+
+export default PostHeader;

--- a/rolling-papaer/src/components/header/PostHeader/PostHeader.jsx
+++ b/rolling-papaer/src/components/header/PostHeader/PostHeader.jsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import FONTS from "../../../theme/font";
-import { useContext } from "react";
 import {
   PostHeaderProvider,
   usePostHeaderContextValue,
@@ -12,7 +11,7 @@ const PostHeaderBlock = styled.header`
   width: 100%;
   height: 68px;
 
-  padding: 13px 360px;
+  padding: 13px calc(max((100% - 1200px) / 2, 24px));
 
   display: flex;
   justify-content: space-between;

--- a/rolling-papaer/src/components/header/PostHeader/PostHeaderItems.jsx
+++ b/rolling-papaer/src/components/header/PostHeader/PostHeaderItems.jsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import { THEME_LIGHT_COLOR } from "../../../theme/color";
+
+const PostHeaderItemsBlock = styled.div`
+  display: flex;
+  align-items: center;
+
+  > * {
+    margin: 0;
+  }
+
+  > *::before {
+    content: "|";
+    color: ${THEME_LIGHT_COLOR.gray2};
+    margin: 0 28px;
+  }
+
+  > *:first-child::before {
+    content: "";
+    margin: 0;
+  }
+`;
+
+function PostHeaderItems({ children }) {
+  return <PostHeaderItemsBlock>{children}</PostHeaderItemsBlock>;
+}
+
+export default PostHeaderItems;

--- a/rolling-papaer/src/components/header/PostHeader/PostHeaderItems.jsx
+++ b/rolling-papaer/src/components/header/PostHeader/PostHeaderItems.jsx
@@ -1,28 +1,40 @@
 import styled from "styled-components";
 import { THEME_LIGHT_COLOR } from "../../../theme/color";
+import React from "react";
 
 const PostHeaderItemsBlock = styled.div`
   display: flex;
   align-items: center;
+  gap: 56px;
 
-  > * {
-    margin: 0;
+  .post-header-item {
+    position: relative;
   }
 
-  > *::before {
+  .post-header-item::before {
+    position: absolute;
+    left: -28px;
+    top: 50%;
+    transform: translateY(-50%);
+    
     content: "|";
     color: ${THEME_LIGHT_COLOR.gray2};
-    margin: 0 28px;
   }
 
-  > *:first-child::before {
+  .post-header-item:first-child::before {
     content: "";
     margin: 0;
   }
 `;
 
 function PostHeaderItems({ children }) {
-  return <PostHeaderItemsBlock>{children}</PostHeaderItemsBlock>;
+  return (
+    <PostHeaderItemsBlock>
+      {React.Children.map(children, (child) => {
+        return (<div className="post-header-item">{child}</div>);
+      })}
+    </PostHeaderItemsBlock>
+  );
 }
 
 export default PostHeaderItems;

--- a/rolling-papaer/src/components/header/PostHeader/PostHeaderProvider.jsx
+++ b/rolling-papaer/src/components/header/PostHeader/PostHeaderProvider.jsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, useState } from "react";
+
+const PostHeaderContext = createContext();
+
+export function PostHeaderProvider({ defaultValue, children }) {
+  const [contextValue] = useState(defaultValue);
+
+  return (
+    <PostHeaderContext.Provider value={{ contextValue }}>
+      {children}
+    </PostHeaderContext.Provider>
+  );
+}
+
+export function usePostHeaderContextValue() {
+  const context = useContext(PostHeaderContext);
+
+  if (!context) {
+    throw new Error("반드시 PostHeaderContext 내부에서 사용할 것");
+  }
+
+  return context.contextValue;
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
### 좌우 padding 반응형
```
padding: 13px calc(max((100% - 1200px) / 2, 24px));
```
header의 width가 1248px까지는 브라우저의 width에 1200px를 뺀 값의 절반만큼을 계속 
그 이하부터는 24px가 더 큰 값이기 때문에 24px로 고정되어 padding이 줄어들지 않습니다.

###  PostHeaderItems 배치 관련 버그 해결
<img width="779" alt="image" src="https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/c44e5883-6984-4ce6-928f-1b767403cdb1">

- 받는 인자가 inline 일 경우 ::before 로 처리한 구분선을 먹어버리는 문제가 있었습니다.
- React.child.map을 이용해서 children을 그냥 받지 않고, 무조건 `post-header-item`가 달린 div 태그로 children내의 요소를 각각 감싸기로 했습니다.
- 그리고 post-header-item에 before를 걸어 받는 인자가 어떠한 display더라도 상관없이 동작하도록 했습니다.
- 다만 우려되는 점은, display:none인 대상이 들어왔을 경우입니다. 이 경우에도 div가 감싸기 때문에 display:none이어도 구분선은 생깁니다.
=> 제가 생각하기에는, 프로젝트 내에서 display:none으로 visible 여부를 다루는 행동은 기본적으로 주의하여야 할 것 같아서 우선 display:none을 모두 사용하지 않는다는 전제 하에 코드를 작성했습니다. 의견 부탁드립니다. (물론 이 컴포넌트를 쓰는 사람은 저밖에 없어요)

```
function PostHeaderItems({ children }) {
  return (
    <PostHeaderItemsBlock>
      {React.Children.map(children, (child) => {
        return (<div className="post-header-item">{child}</div>);
      })}
    </PostHeaderItemsBlock>
  );
}
```

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #43 #46
- Closes #43 #46

## 스크린샷
![ezgif com-video-to-gif-converted (1)](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/ecc2a160-b19c-47fb-a38e-de31541afd6f)
<img width="773" alt="image" src="https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/96b199e6-5bda-4e4f-8dc8-5d3b6a554d23">

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
![giphy (3)](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/896d44ed-2d16-4cda-b8a7-06d313793a39)
