### PR TITLE
[CREATE] Day9 이나경 79 네트워크 통신 custom hook 구현

### DIFF
--- a/rolling-papaer/src/hooks/NetworkHook.jsx
+++ b/rolling-papaer/src/hooks/NetworkHook.jsx
@@ -1,22 +1,25 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 const useAsync = (asyncFunction) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
-  const wrappedFunction = async (...args) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
+  const wrappedFunction = useCallback(
+    async (...args) => {
+      try {
+        setIsLoading(true);
+        setIsError(false);
 
-      return await asyncFunction(...args);
-    } catch (e) {
-      setIsError(true);
-      return;
-    } finally {
-      setIsLoading(false);
-    }
-  };
+        return await asyncFunction(...args);
+      } catch (e) {
+        setIsError(true);
+        return;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [asyncFunction]
+  );
 
   return [isLoading, isError, wrappedFunction];
 };

--- a/rolling-papaer/src/hooks/NetworkHook.jsx
+++ b/rolling-papaer/src/hooks/NetworkHook.jsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+const useAsync = (asyncFunction) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const wrappedFunction = async (...args) => {
+    try {
+      setIsLoading(true);
+      setIsError(false);
+
+      return await asyncFunction(...args);
+    } catch (e) {
+      setIsError(true);
+      return;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return [isLoading, isError, wrappedFunction];
+};
+
+export default useAsync;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
### async 함수를 다루는 useAsync 커스텀 훅
- 지연이 발생되는 활동을 할 때, 발생하는 행동들을 제어할 수 있음
- `isLoading`, `isError`, `wrappedFunction` 반환
1. `isLoading`
- 네트워크 요청중 true
- 종료 혹은 에러발생시 false

2. `isError`
- 에러발생시 true
- 기본 false

3.  `wrappedFunction`
- useAsync의 param으로 전달받은 api 함수를 감싼 함수
- param으로 api함수의 param에 맞는 인자를 전달
- 성공적으로 완료 시 api 결과 값 반환

### CardLazyGridContainer에 useAsync 훅 적용
- getCards 메소드 재구성
```
  const getCards = useCallback(
    async (nextCardIndex, limit) => {
      if (!hasNext) return;
      const firstLimit = nextCardIndex === 0 ? limit - 1 : null;
      const result = await wrappedFunction(nextCardIndex, firstLimit ?? limit);
      if (!result) return;
      const { newCardData, hasMore } = result;
      if (hasMore) {
        setNextCardIndex(nextCardIndex + limit);
      } else {
        setHasNext(false);
      }
      setCardDataList((prevData) => [...prevData, ...newCardData]);
    },
    [hasNext, wrappedFunction]
  );
```
### 초기 데이터 14개가 중복으로 추가되는 문제 해결
- getCards가 비슷한 시점에서 두 번 중복으로 호출되면서 이레 부분에서 의도치 않게, 동일 데이터가 두 번 추가되었음
`setCardDataList((prevData) => [...prevData, ...newCardData]);`

```
  useEffect(() => {
    //TODO: 실제 데이터 가져오기
    getCards(nextCardIndex, limit);
  }, []);
```

```
  const handleInfiniteLoadingObserver = useCallback(
    (entries) => {
      const target = entries[0];
      if (target.isIntersecting) {
        getCards(nextCardIndex, limit);
      }
    },
    [getCards, nextCardIndex, limit]
  );
```
## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #79 
- Closes #79 

## 스크린샷, 녹화
![ezgif com-video-to-gif-converted (4)](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/26940eaa-96ec-47a0-ae96-0511d5b22b7d)

_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [X] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?
=> 해당 문제는 구현 디자인대로 하다보니 발생한 문제로 해결 불가능
<img width="202" alt="image" src="https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/f417ccfc-437b-452a-87b0-23bf44525f77">


## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
![giphy (4)](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/2dd77688-d5c9-4120-92e8-dce0cd31d61d)
