### PR TITLE
[CREATE] Day10 이나경 95 card onclick 연결

### DIFF
--- a/rolling-papaer/src/Main.js
+++ b/rolling-papaer/src/Main.js
@@ -76,7 +76,8 @@ function Main() {
           <Route path="list" element={<RollingPaperListPage />} />
           <Route path="post">
             <Route index element={<PickReceiverPage />} />
-            <Route path=":id" element={<RollingPaperPage />}>
+            <Route path=":id">
+              <Route index  element={<RollingPaperPage />}/>
               <Route path="edit" element={<RollingPaperPage />} />
               <Route path="message" element={<InputMessageContentPage />} />
             </Route>

--- a/rolling-papaer/src/components/card/Card.jsx
+++ b/rolling-papaer/src/components/card/Card.jsx
@@ -54,11 +54,19 @@ const CenteredButtonPlus= styled(ButtonPlus)`
   transform: translateY(-50%) translateX(-50%);
 `;
 
-function Card({ cardData, onClick }) {
+function Card({ cardData, onClick, saveCardDataFunc = (cardData) => {} }) {
+
+  const cardBlockOnClickHandler = () => {
+    if (cardData) {
+      saveCardDataFunc(cardData);
+    }
+    onClick();
+  };
+
   if (cardData) {
     return (
       <CardProvider defaultValue={cardData}>
-        <CardBlock onClick={onClick}>
+        <CardBlock onClick={cardBlockOnClickHandler}>
           <CardProfile>
             {/*//TODO: Profile컴포넌트*/}
             <CardProfileName name={"홍길동"} />
@@ -72,7 +80,7 @@ function Card({ cardData, onClick }) {
     );
   } else {
     return (
-      <CardBlock onClick={onClick}>
+      <CardBlock onClick={cardBlockOnClickHandler}>
         <CenteredButtonPlus type="button">
           <PlusIcon />
         </CenteredButtonPlus>

--- a/rolling-papaer/src/components/card/Card.jsx
+++ b/rolling-papaer/src/components/card/Card.jsx
@@ -54,7 +54,7 @@ const CenteredButtonPlus= styled(ButtonPlus)`
   transform: translateY(-50%) translateX(-50%);
 `;
 
-function Card({ cardData }) {
+function Card({ cardData, onClick }) {
   if (cardData) {
     return (
       <CardProvider defaultValue={cardData}>

--- a/rolling-papaer/src/components/card/CardProvider.jsx
+++ b/rolling-papaer/src/components/card/CardProvider.jsx
@@ -2,16 +2,7 @@ import { createContext, useContext, useState } from "react";
 
 const CardContext = createContext();
 
-const defaultCardValue = {
-    sender: "홍길동",
-    profileImageURL: "https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8",
-    relationship: "동료",
-    content: `일교차가 큰 시기입니다. 새벽에는 겨울, 한낮에는 여름, 아침저녁으로는 가을을 느껴보는 것도 좋을 것 같아요. 일교차가 큰 시기입니다. 새벽에는 겨울, 한낮에는 여름, 아침저녁으로는 가을을 느껴보는 것도 좋은`,
-    font: "Noto Sans",
-    createdAt: "2023-12-12T06:42:43.340806Z"
-}
-
-export function CardProvider({ defaultValue = defaultCardValue, children }) {
+export function CardProvider({ defaultValue , children }) {
   const [contextValue, setContextValue] = useState(defaultValue);
   return (
     <CardContext.Provider

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -3,16 +3,40 @@ import FONTS from "../../theme/font";
 import RelationBadge from "../badge/RelationBadge";
 import ButtonStyle from "../button/ButtonStyle";
 import img from "../../static/person.svg";
+import { useState, useRef, useEffect } from "react";
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      transition: background-color 0.5s;
+      z-index: -1;
+      background-color: ${({ ModalOpen }) =>
+        ModalOpen ? "#00000099" : "transparent"};
+    }
+  }
+`;
 
 const ModalContainer = styled.div`
+  visibility: ${({ ModalOpen }) => ModalOpen ? "visible" : "hidden"};
   position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 60rem;
   padding: 4rem 4.5rem;
+  opacity: ${({ ModalOpen }) => ModalOpen ? "1" : "0"};
   border-radius: 1.6rem;
+  transition: visibility 0.5s;
   box-shadow: 0px 2px 12px 0px #00000014;
+  background-color: var(--white);
 `;
 
 const InfoContainer = styled.div`
@@ -90,9 +114,20 @@ const ButtonContainer = styled.div`
 `;
 
 function Modal() {
+  const [ModalOpen, setModalOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setModalOpen(true);
+  };
+
+  const handleClickClose = () => {
+    setModalOpen(false);
+  };
+
   return (
     <>
-      <ModalContainer>
+      <GlobalStyle ModalOpen={ModalOpen}/>
+      <ModalContainer ModalOpen={ModalOpen}>
         <InfoContainer>
           <UserInfo>
             <div>
@@ -131,11 +166,16 @@ function Modal() {
             size="medium"
             fontSize="fontSize16"
             $padding="padding16"
+            onClick={handleClickClose}
           >
             확인
           </ButtonStyle>
         </ButtonContainer>
       </ModalContainer>
+
+      <button type="button" onClick={handleClickOpen}>
+        버튼
+      </button>
     </>
   );
 }

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -3,7 +3,7 @@ import FONTS from "../../theme/font";
 import RelationBadge from "../badge/RelationBadge";
 import ButtonStyle from "../button/ButtonStyle";
 import img from "../../static/person.svg";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
@@ -11,13 +11,13 @@ const GlobalStyle = createGlobalStyle`
     &::before {
       content: '';
       display: block;
-      position: absolute;
+      position: fixed;
       left: 0;
       top: 0;
       width: 100%;
       height: 100%;
       transition: background-color 0.5s;
-      z-index: -1;
+      z-index: 9998;
       background-color: ${({ $ModalOpen }) =>
         $ModalOpen ? "#00000099" : "transparent"};
     }
@@ -25,18 +25,19 @@ const GlobalStyle = createGlobalStyle`
 `;
 
 const ModalContainer = styled.div`
-  visibility: ${({ $ModalOpen }) => $ModalOpen ? "visible" : "hidden"};
-  position: absolute;
+  visibility: ${({ $ModalOpen }) => ($ModalOpen ? "visible" : "hidden")};
+  position: fixed;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 60rem;
   padding: 4rem 4.5rem;
-  opacity: ${({ $ModalOpen }) => $ModalOpen ? "1" : "0"};
+  opacity: ${({ $ModalOpen }) => ($ModalOpen ? "1" : "0")};
   border-radius: 1.6rem;
   transition: visibility 0.5s;
   box-shadow: 0px 2px 12px 0px #00000014;
   background-color: var(--white);
+  z-index: 9999;
 `;
 
 const InfoContainer = styled.div`
@@ -113,16 +114,50 @@ const ButtonContainer = styled.div`
   text-align: center;
 `;
 
-function Modal() {
-  const [$ModalOpen, setModalOpen] = useState(false);
+function Modal({ sender, createdAt, content, setModalVisible }) {
+  const [$ModalOpen, setModalOpen] = useState(true);
 
-  const handleClickOpen = () => setModalOpen(true);
+  useEffect(() => {
+    const preventScroll = e => {
+      if (e.type === 'keydown' && e.keyCode === 32) {
+        e.preventDefault();
+      } else if (e.type === 'wheel' || e.type === 'touchmove') {
+        e.preventDefault();
+      }
+    };
+  
+    if ($ModalOpen) {
+      window.addEventListener('wheel', preventScroll, { passive: false });
+      window.addEventListener('touchmove', preventScroll, { passive: false });
+      window.addEventListener('keydown', preventScroll, { passive: false });
+    } else {
+      window.removeEventListener('wheel', preventScroll);
+      window.removeEventListener('touchmove', preventScroll);
+      window.removeEventListener('keydown', preventScroll);
+    }
+  
+    return () => {
+      window.removeEventListener('wheel', preventScroll);
+      window.removeEventListener('touchmove', preventScroll);
+      window.removeEventListener('keydown', preventScroll);
+    };
+  }, [$ModalOpen]);
+  
+  
 
-  const handleClickClose = () => setModalOpen(false);
+  const handleClickOpen = () => {
+    setModalVisible(true);
+    setModalOpen(true);
+  };
+
+  const handleClickClose = () => {
+    setModalVisible(false);
+    setModalOpen(false);
+  };
 
   return (
     <>
-      <GlobalStyle $ModalOpen={$ModalOpen}/>
+      <GlobalStyle $ModalOpen={$ModalOpen} />
       <ModalContainer $ModalOpen={$ModalOpen}>
         <InfoContainer>
           <UserInfo>
@@ -131,30 +166,15 @@ function Modal() {
             </div>
             <div>
               <From>
-                From. <span>김동훈</span>
+                From. <span>{sender}</span>
               </From>
               <RelationBadge />
             </div>
           </UserInfo>
-          <Date>2023.07.08</Date>
+          <Date>{createdAt}</Date>
         </InfoContainer>
         <Content>
-          <p>
-            코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
-            하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
-            조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
-            모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
-            체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요.
-            건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는
-            요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을
-            부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시
-            기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가
-            또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
-            하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
-            조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
-            모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
-            체력 모두 조심 또 하세요!
-          </p>
+          <p>{content}</p>
         </Content>
         <ButtonContainer>
           <ButtonStyle
@@ -168,10 +188,6 @@ function Modal() {
           </ButtonStyle>
         </ButtonContainer>
       </ModalContainer>
-
-      <button type="button" onClick={handleClickOpen}>
-        버튼
-      </button>
     </>
   );
 }

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -1,0 +1,143 @@
+import styled from "styled-components";
+import FONTS from "../../theme/font";
+import RelationBadge from "../badge/RelationBadge";
+import ButtonStyle from "../button/ButtonStyle";
+import img from "../../static/person.svg";
+
+const ModalContainer = styled.div`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 60rem;
+  padding: 4rem 4.5rem;
+  border-radius: 1.6rem;
+  box-shadow: 0px 2px 12px 0px #00000014;
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0 1.9rem 0;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  gap: 1.6rem;
+`;
+
+const ProfileImg = styled.img`
+  width: 5.6rem;
+  height: 5.6rem;
+  border-radius: 10rem;
+  border: 1px solid var(--gray2);
+  object-fit: cover;
+`;
+
+const From = styled.p`
+  ${FONTS.FONT_20_REGULAR}
+  margin: 0 0 0.6rem 0;
+
+  span {
+    ${FONTS.FONT_20_BOLD}
+  }
+`;
+
+const Date = styled.span`
+  ${FONTS.FONT_14_REGULAR}
+  color: var(--gray4);
+`;
+
+const Content = styled.div`
+  position: relative;
+  margin: 1.6rem 0 0;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    top: -1.6rem;
+    width: 100%;
+    height: 1px;
+    background-color: var(--gray2);
+  }
+
+  p {
+    margin: 0;
+
+    ${FONTS.FONT_18_REGULAR}
+    overflow: hidden;
+    overflow-y: scroll;
+    height: 24rem;
+    margin: 0 0 2.4rem 0;
+
+    &::-webkit-scrollbar {
+      width: 0.4rem;
+      height: 10rem;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 0.8rem;
+      background-color: var(--gray3);
+    }
+  }
+`;
+
+const ButtonContainer = styled.div`
+  text-align: center;
+`;
+
+function Modal() {
+  return (
+    <>
+      <ModalContainer>
+        <InfoContainer>
+          <UserInfo>
+            <div>
+              <ProfileImg src={img} alt="프로필 이미지" />
+            </div>
+            <div>
+              <From>
+                From. <span>김동훈</span>
+              </From>
+              <RelationBadge />
+            </div>
+          </UserInfo>
+          <Date>2023.07.08</Date>
+        </InfoContainer>
+        <Content>
+          <p>
+            코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
+            하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
+            조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
+            모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
+            체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요.
+            건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는
+            요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을
+            부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시
+            기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가
+            또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
+            하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
+            조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
+            모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
+            체력 모두 조심 또 하세요!
+          </p>
+        </Content>
+        <ButtonContainer>
+          <ButtonStyle
+            $primary="primary"
+            size="medium"
+            fontSize="fontSize16"
+            $padding="padding16"
+          >
+            확인
+          </ButtonStyle>
+        </ButtonContainer>
+      </ModalContainer>
+    </>
+  );
+}
+
+export default Modal;

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -182,7 +182,7 @@ function Modal({ cardData, setModalVisible }) {
               <RelationBadge relation={relationship} />
             </div>
           </UserInfo>
-          <Date>{createdAt}</Date>
+          <Date>{createdAtToDate(createdAt)}</Date>
         </InfoContainer>
         <Content ref={modalContentRef}>
           <p>{content}</p>

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -117,8 +117,9 @@ const ButtonContainer = styled.div`
   text-align: center;
 `;
 
-function Modal({ sender, createdAt, content, setModalVisible }) {
+function Modal({ cardData, setModalVisible }) {
   const [$ModalOpen, setModalOpen] = useState(true);
+  const { sender, relationship, createdAt, content } = cardData;
   const modalContentRef = useRef();
 
   //TODO:  HOOK써서 밖으로 빼낼 수 있을 듯
@@ -178,7 +179,7 @@ function Modal({ sender, createdAt, content, setModalVisible }) {
               <From>
                 From. <span>{sender}</span>
               </From>
-              <RelationBadge />
+              <RelationBadge relation={relationship} />
             </div>
           </UserInfo>
           <Date>{createdAt}</Date>

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -18,21 +18,21 @@ const GlobalStyle = createGlobalStyle`
       height: 100%;
       transition: background-color 0.5s;
       z-index: -1;
-      background-color: ${({ ModalOpen }) =>
-        ModalOpen ? "#00000099" : "transparent"};
+      background-color: ${({ $ModalOpen }) =>
+        $ModalOpen ? "#00000099" : "transparent"};
     }
   }
 `;
 
 const ModalContainer = styled.div`
-  visibility: ${({ ModalOpen }) => ModalOpen ? "visible" : "hidden"};
+  visibility: ${({ $ModalOpen }) => $ModalOpen ? "visible" : "hidden"};
   position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 60rem;
   padding: 4rem 4.5rem;
-  opacity: ${({ ModalOpen }) => ModalOpen ? "1" : "0"};
+  opacity: ${({ $ModalOpen }) => $ModalOpen ? "1" : "0"};
   border-radius: 1.6rem;
   transition: visibility 0.5s;
   box-shadow: 0px 2px 12px 0px #00000014;
@@ -114,20 +114,16 @@ const ButtonContainer = styled.div`
 `;
 
 function Modal() {
-  const [ModalOpen, setModalOpen] = useState(false);
+  const [$ModalOpen, setModalOpen] = useState(false);
 
-  const handleClickOpen = () => {
-    setModalOpen(true);
-  };
+  const handleClickOpen = () => setModalOpen(true);
 
-  const handleClickClose = () => {
-    setModalOpen(false);
-  };
+  const handleClickClose = () => setModalOpen(false);
 
   return (
     <>
-      <GlobalStyle ModalOpen={ModalOpen}/>
-      <ModalContainer ModalOpen={ModalOpen}>
+      <GlobalStyle $ModalOpen={$ModalOpen}/>
+      <ModalContainer $ModalOpen={$ModalOpen}>
         <InfoContainer>
           <UserInfo>
             <div>

--- a/rolling-papaer/src/components/modal/Modal.jsx
+++ b/rolling-papaer/src/components/modal/Modal.jsx
@@ -3,7 +3,7 @@ import FONTS from "../../theme/font";
 import RelationBadge from "../badge/RelationBadge";
 import ButtonStyle from "../button/ButtonStyle";
 import img from "../../static/person.svg";
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`

--- a/rolling-papaer/src/containers/CardLazyGridContainer.jsx
+++ b/rolling-papaer/src/containers/CardLazyGridContainer.jsx
@@ -63,6 +63,8 @@ function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
   const loadingBlock = useRef();
   //TODO: Error 관리
   const [isLoading, isError, wrappedFunction] = useAsync(getCardDataList);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [selectedCardDataForModal, setSelectedCardDataForModal] = useState(null);
 
   const getCards = useCallback(
     async (nextCardIndex, limit) => {
@@ -108,20 +110,37 @@ function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
 
   const handleNullDataCardOnClick = () => {
     nav("message");
-  }
+  };
+
+  const handleDataCardOnClick = () => {
+    //TODO: 모달 실행
+    setIsModalVisible(true);
+  };
 
   //TODO: Card에 onClick 이벤트 넣어야 함
   return (
     <CardLazyGridContainerBlock>
       <CardLazyGridBlock $columnNum={maxCardsPerLine}>
-        <Card onClick={handleNullDataCardOnClick} />
-        {cardDataList.map((cardData) => {
-          return <Card key={cardData.id} cardData={cardData} />;
-        })}
       </CardLazyGridBlock>
       {isLoading && <LoadingAnimator src={loadingImg} alt={"Loading"} />}
       {hasNext && !isLoading && (
         <LoaderObserver ref={loadingBlock}></LoaderObserver>
+          <Card onClick={handleNullDataCardOnClick} />
+          {cardDataList.map((cardData) => {
+            return (
+              <Card
+                key={cardData.id}
+                cardData={cardData}
+                onClick={handleDataCardOnClick}
+                saveCardDataFunc={setSelectedCardDataForModal}
+              />
+            );
+          })}
+      {isModalVisible && (
+        <Modal
+          cardData={selectedCardDataForModal}
+          setModalVisible={setIsModalVisible}
+        />
       )}
     </CardLazyGridContainerBlock>
   );

--- a/rolling-papaer/src/containers/CardLazyGridContainer.jsx
+++ b/rolling-papaer/src/containers/CardLazyGridContainer.jsx
@@ -4,6 +4,7 @@ import Card from "../components/card/Card";
 import { getCardDataList } from "../api/apis";
 import loadingImg from "../static/loading.svg";
 import useAsync from "../hooks/NetworkHook";
+import { NavLink, useNavigate } from "react-router-dom";
 
 const LoadingAnimator = styled.img`
   margin-top: 50px;
@@ -54,6 +55,7 @@ const CardLazyGridBlock = styled.div`
 `;
 
 function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
+  const nav = useNavigate();
   const [cardDataList, setCardDataList] = useState([]);
   const [nextCardIndex, setNextCardIndex] = useState(0);
   const [hasNext, setHasNext] = useState(true);
@@ -104,11 +106,15 @@ function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
     };
   }, [handleInfiniteLoadingObserver]);
 
+  const handleNullDataCardOnClick = () => {
+    nav("message");
+  }
+
   //TODO: Card에 onClick 이벤트 넣어야 함
   return (
     <CardLazyGridContainerBlock>
       <CardLazyGridBlock $columnNum={maxCardsPerLine}>
-        <Card />
+        <Card onClick={handleNullDataCardOnClick} />
         {cardDataList.map((cardData) => {
           return <Card key={cardData.id} cardData={cardData} />;
         })}

--- a/rolling-papaer/src/containers/CardLazyGridContainer.jsx
+++ b/rolling-papaer/src/containers/CardLazyGridContainer.jsx
@@ -5,6 +5,7 @@ import { getCardDataList } from "../api/apis";
 import loadingImg from "../static/loading.svg";
 import useAsync from "../hooks/NetworkHook";
 import { NavLink, useNavigate } from "react-router-dom";
+import Modal from "../components/modal/Modal";
 
 const LoadingAnimator = styled.img`
   margin-top: 50px;
@@ -64,7 +65,8 @@ function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
   //TODO: Error 관리
   const [isLoading, isError, wrappedFunction] = useAsync(getCardDataList);
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [selectedCardDataForModal, setSelectedCardDataForModal] = useState(null);
+  const [selectedCardDataForModal, setSelectedCardDataForModal] =
+    useState(null);
 
   const getCards = useCallback(
     async (nextCardIndex, limit) => {
@@ -121,21 +123,22 @@ function CardLazyGridContainer({ postId, maxCardsPerLine = 3 }) {
   return (
     <CardLazyGridContainerBlock>
       <CardLazyGridBlock $columnNum={maxCardsPerLine}>
+        <Card onClick={handleNullDataCardOnClick} />
+        {cardDataList.map((cardData) => {
+          return (
+            <Card
+            key={cardData.id}
+            cardData={cardData}
+            onClick={handleDataCardOnClick}
+            saveCardDataFunc={setSelectedCardDataForModal}
+            />
+            );
+          })}
       </CardLazyGridBlock>
       {isLoading && <LoadingAnimator src={loadingImg} alt={"Loading"} />}
       {hasNext && !isLoading && (
         <LoaderObserver ref={loadingBlock}></LoaderObserver>
-          <Card onClick={handleNullDataCardOnClick} />
-          {cardDataList.map((cardData) => {
-            return (
-              <Card
-                key={cardData.id}
-                cardData={cardData}
-                onClick={handleDataCardOnClick}
-                saveCardDataFunc={setSelectedCardDataForModal}
-              />
-            );
-          })}
+      )}
       {isModalVisible && (
         <Modal
           cardData={selectedCardDataForModal}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
### Card onClick Prop 추가
- Card 내에 `cardBlockOnClickHandler` 함수에서  `onClick` 실행
- `cardBlockOnClickHandler`를 `CardBlock`의 `onClick`에 전달

### Card saveCardDataFunc  Prop 추가
- Card 내 `cardBlockOnClickHandler` 함수에서 `cardData`가 있을 시 `saveCardDataFunc(cardData)` 콜백 실행

### 데이터 없는 Card 클릭 핸들러
- message 페이지로 이동

### 데이터 있는 Card 클릭 핸들러
- modal visible 처리
- cardData modal에 전달

### Modal 버그 수정
1. `z-index : -1` 설정
- body의 맨 뒤에 modal이 위치하여 modal이 가려짐 
2. 외부 스크롤이 되는 오류 해결
- `useEffect` 및 `preventDefault` 함수로 스크롤 제어
-   `overscroll-behavior: contain;` 사용하여 스크롤 체이닝 방지



## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #95 
- Closes #95 

## 스크린샷, 녹화

_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
![giphy (7)](https://github.com/RollingPaperTeam/rolling-papaer-web/assets/66313756/96a74cc0-3450-432b-86a3-2dca7b41a202)